### PR TITLE
Potential fix for code scanning alert no. 5: Server-side request forgery

### DIFF
--- a/src/findAnimeName.ts
+++ b/src/findAnimeName.ts
@@ -3,10 +3,30 @@ import * as cheerio from 'cheerio';
 
 export async function regenerate_path(orgin_biliLink: string) {
   const domain = 'https://www.bilibili.tv';
-  const path = orgin_biliLink.replace(domain, '');
-  const newPath = path.replace(/\/(en|th)\//, '/play/');
 
-  return domain + newPath;
+  try {
+    const url = new URL(orgin_biliLink);
+
+    // Enforce allowed scheme and host to mitigate SSRF
+    if (url.protocol !== 'https:' || url.hostname !== 'www.bilibili.tv') {
+      throw new Error('Unsupported Bilibili URL domain or protocol.');
+    }
+
+    // Normalize the path: turn /en/ or /th/ into /play/ within the pathname
+    const normalizedPath = url.pathname.replace(/\/(en|th)\//, '/play/');
+
+    // Reconstruct the URL using the trusted domain and normalized path
+    const normalizedUrl =
+      domain +
+      normalizedPath +
+      (url.search || '') +
+      (url.hash || '');
+
+    return normalizedUrl;
+  } catch (e) {
+    // If URL parsing or validation fails, propagate the error to be handled by the caller
+    throw new Error('Invalid Bilibili URL provided.');
+  }
 }
 
 export async function findName(biliLink: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,18 @@ app.get(/\/api$/, async (req, res) => {
         const link = match[1];
         const title = BiliLink.replace(link, '').trim();
 
+        // Validate that the extracted link points to the allowed Bilibili TV domain
+        let parsedUrl: URL;
+        try {
+            parsedUrl = new URL(link);
+        } catch {
+            return res.status(400).json({ error: 'Invalid URL format for Bilibili link.' });
+        }
+
+        if (parsedUrl.protocol !== 'https:' || parsedUrl.hostname !== 'www.bilibili.tv') {
+            return res.status(400).json({ error: 'Only https://www.bilibili.tv URLs are allowed.' });
+        }
+
         BiliLink = link;
 
         if (BiliLink) {


### PR DESCRIPTION
Potential fix for [https://github.com/kang49/bilibili-story-sharing/security/code-scanning/5](https://github.com/kang49/bilibili-story-sharing/security/code-scanning/5)

**General approach**

To fix this, we should ensure that any URL used in outgoing HTTP requests is validated against a strict allow‑list of acceptable scheme and host (and optionally path prefix). In this context, we only want to allow `https://www.bilibili.tv/...` (or whatever Bilibili TV domains you truly support). That means:

- Parse the user-provided value into a `URL` object.
- Verify:
  - `protocol === 'https:'`
  - `hostname === 'www.bilibili.tv'` (and possibly a small, explicit set of allowed hosts if needed).
- Optionally enforce that the path starts with an expected prefix (such as `/en/`, `/th/`, or `/play/`).
- Reject (HTTP 400) any request that fails validation, and never pass such a URL into `axios.get`.

Additionally, `regenerate_path` should operate on a parsed URL object and always rebuild the final URL using the trusted domain, rather than simple string replacement on the entire input.

**Best fix with minimal functional change**

We’ll implement validation in two places:

1. **At the API boundary in `src/index.ts`** (before calling `findName`):
   - After extracting `link` from `BiliLink`, we will:
     - Try to construct `new URL(link)`.
     - Check that `url.protocol === 'https:'` and `url.hostname === 'www.bilibili.tv'`.
     - If validation fails, respond with `400` and an explanatory error (e.g., “Only https://www.bilibili.tv URLs are allowed.”) and do not call `findName`.
   - This stops obviously malicious URLs before they enter deeper logic.

2. **Inside `src/findAnimeName.ts`**:
   - Strengthen `regenerate_path` to:
     - Parse `orgin_biliLink` with `new URL`.
     - Verify the hostname is `www.bilibili.tv` (and protocol `https:`).
     - Force the output to always be `https://www.bilibili.tv` plus a normalized path, ignoring any original scheme/host.
     - If parsing or validation fails, throw an error so `findName` can catch and handle it.
   - In `findName`, we’ll:
     - Accept `biliLink` as a string but rely on `regenerate_path` to enforce the domain; if it throws, we catch and return the existing error array.
     - Optionally, defensively re-parse the normalized `biliLink` to confirm its host before issuing `axios.get`, although with the above change it should always be safe.

This preserves existing behaviour for legitimate `https://www.bilibili.tv/...` URLs while preventing SSRF via other domains or schemes.

**Concrete changes**

- `src/index.ts`:
  - In the `/api` handler, after `const link = match[1];`, insert validation using the standard `URL` class (no new imports required).
  - If validation fails, return `400` and skip calling `findName`.

- `src/findAnimeName.ts`:
  - Rewrite `regenerate_path` to:
    - Use `new URL(orgin_biliLink)`.
    - Confirm the hostname is `www.bilibili.tv`.
    - Normalize the path:
      - Take `url.pathname`.
      - Replace `/en/` or `/th/` with `/play/` only in the path segment, e.g. `pathname.replace(/\/(en|th)\//, '/play/')`.
    - Return `https://www.bilibili.tv` + normalized path + (optionally) `url.search` and `url.hash` if those are desired; to minimize functional change, we can preserve search and hash.
  - Wrap this logic in `try/catch` and throw an error on invalid URLs so that `findName`’s existing outer `try/catch` returns the generic error array.

No external dependencies are needed; Node’s built-in `URL` is sufficient in TypeScript as well (it’s standard in the runtime environment).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
