### PR TITLE
Potential fix for code scanning alert no. 5: Server-side request forgery

### DIFF
--- a/src/findAnimeName.ts
+++ b/src/findAnimeName.ts
@@ -1,6 +1,10 @@
 import axios from 'axios';
 import * as cheerio from 'cheerio';
 
+function isAllowedBilibiliUrl(url: URL): boolean {
+  return url.protocol === 'https:' && url.hostname === 'www.bilibili.tv';
+}
+
 export async function regenerate_path(orgin_biliLink: string) {
   const domain = 'https://www.bilibili.tv';
 
@@ -8,7 +12,7 @@ export async function regenerate_path(orgin_biliLink: string) {
     const url = new URL(orgin_biliLink);
 
     // Enforce allowed scheme and host to mitigate SSRF
-    if (url.protocol !== 'https:' || url.hostname !== 'www.bilibili.tv') {
+    if (!isAllowedBilibiliUrl(url)) {
       throw new Error('Unsupported Bilibili URL domain or protocol.');
     }
 
@@ -54,7 +58,21 @@ export async function findName(biliLink: string) {
   try {
     // Fetch the original page to get the response URL for possible redirection
     const initialResponse = await axios.get(biliLink);
-    const redirectedLink = initialResponse.request.res.responseUrl;
+    const redirectedLink: string =
+      (initialResponse.request && initialResponse.request.res && initialResponse.request.res.responseUrl) ||
+      biliLink;
+
+    let parsedRedirectUrl: URL;
+    try {
+      parsedRedirectUrl = new URL(redirectedLink);
+    } catch {
+      throw new Error('Invalid redirect URL from Bilibili.');
+    }
+
+    // Enforce allowed scheme and host on redirect to mitigate SSRF
+    if (!isAllowedBilibiliUrl(parsedRedirectUrl)) {
+      throw new Error('Unsupported redirect domain or protocol from Bilibili.');
+    }
     
     // Ensure we have both /en/ and /th/ versions
     let enBiliLink: string;


### PR DESCRIPTION
Potential fix for [https://github.com/kang49/bilibili-story-sharing/security/code-scanning/5](https://github.com/kang49/bilibili-story-sharing/security/code-scanning/5)

General approach: Ensure that *every* URL used in outgoing HTTP requests is restricted to allowed schemes and hosts, including URLs obtained via redirects. Introduce a small helper to validate URLs, and apply it both to the initial input and to any redirect URLs before using them. If the redirect does not meet the constraints, abort instead of following/using it. Also, guard against missing `responseUrl` to avoid runtime errors.

Best concrete fix for this code:

- Keep `regenerate_path`’s logic but refactor the validation into a reusable helper, e.g. `isAllowedBilibiliUrl(url: URL): boolean`, so we can apply the same checks to `redirectedLink`.
- In `findName`, after `axios.get(biliLink)` and before using `initialResponse.request.res.responseUrl`, parse that redirect URL into a `URL` object and validate:
  - Scheme must be `https:`.
  - Hostname must be exactly `www.bilibili.tv`.
- If the redirect is missing or invalid, throw or return an error instead of proceeding.
- Optionally, disable further redirects on the *second* set of requests (`fetchPageName`) to ensure we only ever follow the one redirect we explicitly validated.

Where and what to change:

1. In `src/findAnimeName.ts`:
   - Above `regenerate_path`, add a small helper `function isAllowedBilibiliUrl(parsed: URL): boolean` that enforces the `https` + `www.bilibili.tv` constraint.
   - Update `regenerate_path` to use this helper instead of duplicating the checks.
   - In `findName`:
     - After `const initialResponse = await axios.get(biliLink);`, obtain `redirectedLink` more defensively, e.g. `(initialResponse.request?.res?.responseUrl as string) || biliLink`.
     - Parse `redirectedLink` using `new URL(redirectedLink)` and validate with `isAllowedBilibiliUrl`. If invalid, throw an error.
     - Optionally, pass `{ maxRedirects: 0 }` to `axios.get` calls inside `fetchPageName` so that we don’t silently follow any further redirects without validation.

These changes preserve existing functionality (still following Bilibili redirects and deriving `/en/` and `/th/` URLs) while ensuring every outgoing URL is constrained to the allowed host and scheme, thus addressing all three CodeQL variants that stem from user-controlled input.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
